### PR TITLE
refactor: don't revert deployment on non-existant configs

### DIFF
--- a/script/DeploymentConfig.s.sol
+++ b/script/DeploymentConfig.s.sol
@@ -20,13 +20,11 @@ contract DeploymentConfig is Script {
     address public immutable deployer;
 
     constructor(address _broadcaster) {
-        if (block.chainid == 31_337) {
-            (ownerTokenConfig, masterTokenConfig) = getOrCreateAnvilEthConfig();
-        } else {
-            revert("no network config for this chain");
-        }
         if (_broadcaster == address(0)) revert DeploymentConfig_InvalidDeployerAddress();
         deployer = _broadcaster;
+        if (block.chainid == 31_337) {
+            (ownerTokenConfig, masterTokenConfig) = getOrCreateAnvilEthConfig();
+        }
     }
 
     function getOrCreateAnvilEthConfig() public pure returns (TokenConfig memory, TokenConfig memory) {


### PR DESCRIPTION
At this point, the contracts that need to be deployed do not require chain specific configurations. The ones provided for local test nodes are used in tests that don't represent the production deployment.

Hence, there's little point in reverting the deployment if there's no config for a specific chain.

This commit also moves the `deployer` assignment to the beginning of the constructor, ensuring that it's set when configs are created.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
