### PR TITLE
chore: add certora rules for `CollectibleV1`

### DIFF
--- a/certora/certora.conf
+++ b/certora/certora.conf
@@ -1,0 +1,11 @@
+{
+  "files": ["contracts/tokens/CollectibleV1.sol", "contracts/tokens/OwnerToken.sol", "contracts/tokens/MasterToken.sol", "certora/harness/CollectibleV1Harness.sol"],
+  "verify": "CollectibleV1Harness:certora/specs/CollectibleV1.spec",
+  "link": ["CollectibleV1Harness:ownerToken=OwnerToken", "CollectibleV1Harness:masterToken=MasterToken"],
+  "packages": ["@openzeppelin=lib/openzeppelin-contracts"],
+  "optimistic_loop": true,
+  "loop_iter": "3",
+  "msg": "Verifying CollectibleV1.sol",
+  "rule_sanity": "basic"
+}
+

--- a/certora/harness/CollectibleV1Harness.sol
+++ b/certora/harness/CollectibleV1Harness.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Mozilla Public License 2.0
+pragma solidity ^0.8.17;
+
+import { CollectibleV1 } from "../../contracts/tokens/CollectibleV1.sol";
+
+contract CollectibleV1Harness is CollectibleV1 {
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint256 maxSupply,
+        bool remoteBurnable,
+        bool transferable,
+        string memory baseURI,
+        address ownerToken,
+        address masterToken
+    ) CollectibleV1(name, symbol, maxSupply, remoteBurnable, transferable, baseURI, ownerToken, masterToken) {}
+
+    /**
+     * @notice A helper function to count the number of occurrences of an address in a list.
+     */
+    function countAddresses(address[] memory list, address addr) external pure returns (uint) {
+        uint256 count = 0;
+        for (uint256 i = 0; i < list.length; i++) {
+            if (list[i] == addr) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/certora/specs/CollectibleV1.spec
+++ b/certora/specs/CollectibleV1.spec
@@ -4,11 +4,93 @@ methods {
   function transferable() external returns (bool) envfree;
   function totalSupply() external returns (uint) envfree;
   function maxSupply() external returns (uint) envfree;
+  function mintTo(address[]) external;
+  function mintedCount() external returns (uint) envfree;
+  function countAddresses(address[], address) external returns (uint) envfree;
+  function _.onERC721Received(address, address, uint256, bytes) external => NONDET;
 }
 
-rule shouldPass {
-  assert true;
+function safeAssumptions() {
+  requireInvariant mintCountGreaterEqualTotalSupply();
 }
+
+invariant mintCountGreaterEqualTotalSupply()
+  mintedCount() >= totalSupply();
+
+rule mintToCanNotMintMoreThanMaxSupply {
+  address[] addresses;
+  env e;
+
+  mathint totalSupply_before = totalSupply();
+  mathint maxSupply = to_mathint(maxSupply());
+
+  require totalSupply_before < maxSupply;
+  safeAssumptions();
+
+  mintTo@withrevert(e, addresses);
+  bool failed = lastReverted;
+  assert (totalSupply_before + addresses.length > maxSupply) => failed;
+  /* FOOT GUN! */
+  /* loop unfolding */
+}
+
+
+rule mintToRelations() {
+  address[] addresses_1;
+  address[] addresses_2;
+  env e;
+
+  require addresses_1.length == 2;
+  require addresses_1.length == addresses_2.length;
+
+  require addresses_1[0] != addresses_1[1];
+  require addresses_1[0] == addresses_2[1];
+  require addresses_1[1] == addresses_2[0];
+
+  mathint supply_before = totalSupply();
+  mathint max_supply = maxSupply();
+  mathint minted_count = mintedCount();
+
+  require supply_before <= max_supply;
+  require minted_count >= supply_before;
+
+  address a;
+
+  storage s1 = lastStorage;
+  mintTo(e, addresses_1);
+  mathint balance_s1 = balanceOf(a);
+
+  mintTo(e, addresses_2) at s1;
+
+  mathint balance_s2 = balanceOf(a);
+  assert balance_s1 == balance_s2;
+}
+
+
+rule integrityOfMintTo {
+
+  address[] addresses;
+  env e;
+
+  mathint totalSupply_before = totalSupply();
+  mathint maxSupply = to_mathint(maxSupply());
+
+  address addr;
+
+  require totalSupply_before < maxSupply;
+  require totalSupply_before + addresses.length <= maxSupply;
+
+  mathint balance_addr_before = balanceOf(addr);
+  mathint count = countAddresses(addresses, addr);
+  mintTo(e, addresses);
+
+  mathint totalSupply_after = totalSupply();
+  mathint balance_addr_after = balanceOf(addr);
+
+  assert totalSupply_after == totalSupply_before + addresses.length;
+  assert balance_addr_after == balance_addr_before + count;
+}
+
 
 /* rule sanity(env e, method f) { */
 /*     calldataarg args; */


### PR DESCRIPTION
This adds certora rules for the `CollectibleV1` contract, including integrity of `mintTo`.
It also adds a `CollectibleV1Harness` contract so we get access to a helper function.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
- [x] Ran `pnpm verify`?
