### PR TITLE
ci(workflows): only add opened PRs to project board

### DIFF
--- a/.github/workflows/add-prs-to-review-to-vac-board.yml
+++ b/.github/workflows/add-prs-to-review-to-vac-board.yml
@@ -2,6 +2,8 @@ name: Add PRs to review Vac task board
 
 on:
   pull_request:
+    types:
+      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Otherwise the automation will signal failure every time one pushes into an existing PR.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [ ] Ran `pnpm verify`?
