### PR TITLE
chore(ci): update certora cli to latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
         with: { java-version: "11", java-package: jre }
 
       - name: Install Certora CLI
-        run: pip3 install certora-cli==7.0.7
+        run: pip3 install certora-cli==7.22.2
 
       - name: Install Solidity
         run: |

--- a/certora/specs/CommunityTokenDeployer.spec
+++ b/certora/specs/CommunityTokenDeployer.spec
@@ -9,9 +9,6 @@ methods {
 
   function CommunityOwnerTokenRegistry.getEntry(address) external returns (address) envfree;
   function CommunityOwnerTokenRegistry.tokenDeployer() external returns (address) envfree;
-
-
-  function _.balanceOf(address _owner) external => DISPATCHER(true);
 }
 
 rule integrityOfDeploy {


### PR DESCRIPTION
This commit updates the certora CLI to the latest version (7.10.1) in CI tasks.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [x] Ran `pnpm verify`?
